### PR TITLE
Fix expressions support in variables

### DIFF
--- a/tst/template_test_data.yml
+++ b/tst/template_test_data.yml
@@ -14,6 +14,7 @@ vars:
   dict:
     a: 1
     b: 2
+  json_s: '{"a": 1, "b": 2}'
 tests:
 - in: "{{ yes_s }}/asd/{{ no_s }}"
   out: yes/asd/no
@@ -66,3 +67,30 @@ tests:
       b:
         a: 1
         b: 2
+# string input should have string output
+- in: "{{ json_s }}"
+  out: '{"a": 1, "b": 2}'
+- in: "{{ dict }}"
+  out:
+    a: 1
+    b: 2
+# to_json output should be a string
+- in: "{{ dict | to_json }}"
+  out: '{"a": 1, "b": 2}'
+- in: '"{{ json_s }}"'
+  out: '"{"a": 1, "b": 2}"'
+# expressions inside template should work
+- in: "{{ 20 % 7 }}"
+  out: 6
+- in: "{{ list | join(', ') }}"
+  out: "1, 2, 3"
+- in: >-
+    {% if list %}<ul>{% for i in list %}
+      <li>{{ i }}</li>{% endfor %}
+    </ul>{% endif%}
+  out: >-
+    <ul>
+      <li>1</li>
+      <li>2</li>
+      <li>3</li>
+    </ul>

--- a/yaml_requests/utils/template.py
+++ b/yaml_requests/utils/template.py
@@ -41,7 +41,12 @@ class Environment(_J2_Environment):
             return str_in
 
         if self._is_template(str_in):
-            str_in = str_in.replace('}}', ' | to_json }}')
+            # If input is a template, append to_json filter to maintain
+            # original data type. This requires wrapping template expression
+            # from user in parentheses to avoid issues with operator
+            # predendence.
+            str_in = str_in.replace('{{', '{{ (')
+            str_in = str_in.replace('}}', ') | to_json }}')
         template = self.from_string(str_in)
         rendered = template.render()
 


### PR DESCRIPTION
Previously some expressions (e.g., `{{ 20 % 7 }}`) inside template variables caused errors, because `to_json` filter is added to the expression when resolving the templates to maintain original data type.